### PR TITLE
Use standard format and add code analyzer

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -28,6 +28,6 @@ config :phoenix, :json_library, Jason
 # Import environment specific config. This must remain at the bottom
 # of this file so it overrides the configuration defined above.
 
-if (Mix.env() != "prod") do
+if Mix.env() != "prod" do
   import_config "#{Mix.env()}.exs"
 end

--- a/config/dev.exs
+++ b/config/dev.exs
@@ -29,7 +29,6 @@ config :stabby_flies, StabbyFlies.Repo,
   hostname: "localhost",
   pool_size: 10
 
-
 # ## SSL Support
 #
 # In order to use HTTPS in development, a self-signed

--- a/config/prod.exs
+++ b/config/prod.exs
@@ -18,7 +18,8 @@ config :stabby_flies, StabbyFliesWeb.Endpoint,
   check_origin: ["https://meaty-spiffy-hermitcrab.gigalixirapp.com/"],
   cache_static_manifest: "priv/static/cache_manifest.json",
   # render_errors: [view: StabbyFliesWeb.ErrorView, accepts: ~w(html json)],
-  pubsub: [name: StabbyFlies.PubSub, adapter: Phoenix.PubSub.PG2] # Not certain we need this!
+  # Not certain we need this!
+  pubsub: [name: StabbyFlies.PubSub, adapter: Phoenix.PubSub.PG2]
 
 # config :stabby_flies, StabbyFliesWeb.Endpoint,
 #   http: [:inet6, port: System.get_env("PORT") || 4000],
@@ -80,8 +81,6 @@ config :logger, level: :info
 
 # Finally import the config/prod.secret.exs which should be versioned
 # separately.
-
-
 
 config :stabby_flies, StabbyFlies.Repo,
   adapter: Ecto.Adapters.Postgres,

--- a/lib/stabby_flies/application.ex
+++ b/lib/stabby_flies/application.ex
@@ -21,7 +21,7 @@ defmodule StabbyFlies.Application do
     opts = [strategy: :one_for_one, name: StabbyFlies.Supervisor]
     Supervisor.start_link(children, opts)
     StabbyFlies.Game.start_link(1)
-    StabbyFlies.SocketIdGen.start_link
+    StabbyFlies.SocketIdGen.start_link()
   end
 
   # Tell Phoenix to update the endpoint configuration

--- a/lib/stabby_flies/game.ex
+++ b/lib/stabby_flies/game.ex
@@ -74,7 +74,7 @@ defmodule StabbyFlies.Game do
     player
   end
 
-  def reset() do
+  def reset do
     Agent.update(__MODULE__, fn _state -> %{} end)
   end
 
@@ -135,30 +135,32 @@ defmodule StabbyFlies.Game do
     correct_up = direction[:up] and !direction[:down]
     correct_down = direction[:down] and !direction[:up]
 
-    correct_direction = %{
+    # Rotation (in radians) of the sword based off the keys pressed
+    correct_direction(%{
       left: correct_left,
       right: correct_right,
       up: correct_up,
-      down: correct_down
-    }
-
-    # Rotation (in radians) of the sword based off the keys pressed
-    ret_dir =
-      case correct_direction do
-        %{left: false, right: false, up: false, down: false} -> player[:sword_rotation]
-        %{left: true, right: false, up: false, down: false} -> -:math.pi() / 2
-        %{left: true, right: false, up: true, down: false} -> -:math.pi() / 3
-        %{left: true, right: false, up: false, down: true} -> 3.92699
-        %{left: false, right: true, up: false, down: false} -> :math.pi() / 2
-        %{left: false, right: true, up: true, down: false} -> :math.pi() / 3
-        %{left: false, right: true, up: false, down: true} -> -3.92699
-        %{left: false, right: false, up: true, down: false} -> 0
-        %{left: false, right: false, up: false, down: true} -> :math.pi()
-      end
-
-    ret_dir
+      down: correct_down,
+      sword_rotation: player[:sword_rotation]
+    })
   end
 
+  defp correct_direction(%{left: true, right: false, up: false, down: false, sword_rotation: _sword_rotation}), do: :math.pi() / 2
+  defp correct_direction(%{left: true, right: false, up: true, down: false, sword_rotation: _sword_rotation}), do: -:math.pi() / 3
+  defp correct_direction(%{left: true, right: false, up: false, down: true, sword_rotation: _sword_rotation}), do: 3.92699
+  defp correct_direction(%{left: false, right: true, up: false, down: false, sword_rotation: _sword_rotation}), do: :math.pi() / 2
+  defp correct_direction(%{left: false, right: true, up: true, down: false, sword_rotation: _sword_rotation}), do: :math.pi() / 3
+  defp correct_direction(%{left: false, right: true, up: false, down: true, sword_rotation: _sword_rotation}), do: -3.92699
+  defp correct_direction(%{left: false, right: false, up: true, down: false, sword_rotation: _sword_rotation}), do: 0
+  defp correct_direction(%{left: false, right: false, up: false, down: true, sword_rotation: _sword_rotation}), do: :math.pi()
+  defp correct_direction(%{
+         left: false,
+         right: false,
+         up: false,
+         down: false,
+         sword_rotation: sword_rotation
+       }),
+       do: sword_rotation
   def do_damage_to_player(socket_id, damage) do
     Agent.update(__MODULE__, fn state ->
       player = get_player_by_socket_id(socket_id, state.players)
@@ -283,10 +285,10 @@ defmodule StabbyFlies.Game do
     end
   end
 
-  defp update_hp(hp, change, maxHp) do
+  defp update_hp(hp, change, max_hp) do
     cond do
       hp + change <= 0 -> 0
-      hp + change >= maxHp -> maxHp
+      hp + change >= max_hp -> max_hp
       true -> hp + change
     end
   end

--- a/lib/stabby_flies/game.ex
+++ b/lib/stabby_flies/game.ex
@@ -8,87 +8,100 @@ defmodule StabbyFlies.Game do
   use Agent
 
   def start_link(_) do
-    Agent.start_link(fn -> %{ "players": [] } end, name: __MODULE__)
+    Agent.start_link(fn -> %{players: []} end, name: __MODULE__)
     {:ok, _} = :timer.apply_interval(50, __MODULE__, :game_loop, [])
   end
 
   def game_loop do
-    get_players |> Enum.each fn player -> 
+    get_players
+    |> Enum.each(fn player ->
       update_player(player)
       StabbyFliesWeb.Endpoint.broadcast("room:game", "update_player", player)
-    end
+    end)
   end
 
   def respawn_player(socket_id) do
-    Agent.update(__MODULE__, fn(state) ->
+    Agent.update(__MODULE__, fn state ->
       player = get_player_by_socket_id(socket_id, state.players)
-      updated_player = Map.merge(player, %{hp: player.maxHp, y: start_y, x: start_x, kill_count: 0, moving: %{left: false, up: false, down: false, right: false}})
+
+      updated_player =
+        Map.merge(player, %{
+          hp: player.maxHp,
+          y: start_y,
+          x: start_x,
+          kill_count: 0,
+          moving: %{left: false, up: false, down: false, right: false}
+        })
+
       players_excluding_player = List.delete(state.players, player)
-      Map.put(state, :players, [updated_player | players_excluding_player] )
+      Map.put(state, :players, [updated_player | players_excluding_player])
     end)
   end
 
   def set_player_moving(socket_id, direction, moving) do
-    Agent.update(__MODULE__, fn(state) ->
+    Agent.update(__MODULE__, fn state ->
       player = get_player_by_socket_id(socket_id, state.players)
-      
+
       updated_player = put_in(player[:moving][direction], moving)
       players_excluding_player = List.delete(state.players, player)
-      Map.put(state, :players, [updated_player | players_excluding_player] )
+      Map.put(state, :players, [updated_player | players_excluding_player])
     end)
   end
 
   def add_player(name, socket_id) do
     x = start_x
     y = start_y
+
     player = %{
       name: name,
-      x: x, 
-      y: y, 
-      socket_id: socket_id, 
+      x: x,
+      y: y,
+      socket_id: socket_id,
       moving: %{left: false, up: false, down: false, right: false},
       sword_rotation: 0,
       hp: 10,
       maxHp: 10,
-      last_stab: Time.utc_now,
+      last_stab: Time.utc_now(),
       speed: 20 * 10,
       kill_count: 0,
       damage: 5
     }
 
-    Agent.update(__MODULE__, fn(state) -> 
-      Map.put(state, :players, [player | state.players] )
+    Agent.update(__MODULE__, fn state ->
+      Map.put(state, :players, [player | state.players])
     end)
+
     player
   end
 
   def reset() do
-    Agent.update(__MODULE__, fn(_state) -> %{} end)
+    Agent.update(__MODULE__, fn _state -> %{} end)
   end
 
   def get_players do
-    Agent.get(__MODULE__, fn(state) ->
+    Agent.get(__MODULE__, fn state ->
       state.players
     end)
   end
 
   def get_player_by_name(name) do
-    get_players() |> Enum.find([], fn x -> x[:name] == name end )
+    get_players() |> Enum.find([], fn x -> x[:name] == name end)
   end
 
   def get_player_by_socket_id(socket_id) do
-    get_players() |> Enum.find([], fn x -> x[:socket_id] == socket_id end )
+    get_players() |> Enum.find([], fn x -> x[:socket_id] == socket_id end)
   end
+
   def get_player_by_socket_id(socket_id, player_list) do
-    player_list|> Enum.find([], fn x -> x[:socket_id] == socket_id end )
+    player_list |> Enum.find([], fn x -> x[:socket_id] == socket_id end)
   end
 
   def update_player(player) do
-    if (player.hp <= 0) do
+    if player.hp <= 0 do
       respawn_player(player.socket_id)
     else
-      speed = player.speed / 10 # this should be proportional to the loop timer
-      
+      # this should be proportional to the loop timer
+      speed = player.speed / 10
 
       y_speed_up = if player[:moving][:up], do: -speed, else: 0
       y_speed_down = if player[:moving][:down], do: speed, else: 0
@@ -99,17 +112,17 @@ defmodule StabbyFlies.Game do
       x_speed_right = if player[:moving][:right], do: speed, else: 0
 
       new_x = update_x(player.x, x_speed_left + x_speed_right)
-    
+
       if new_x != 0 or new_y != 0 do
-        Agent.update(__MODULE__, fn(state) ->
+        Agent.update(__MODULE__, fn state ->
           player_now = get_player_by_socket_id(player.socket_id, state.players)
           new_rotation = get_rotation(player_now)
 
-          updated_player =  %{player_now | x: new_x }
-          updated_player =  %{updated_player | y: new_y }
+          updated_player = %{player_now | x: new_x}
+          updated_player = %{updated_player | y: new_y}
           updated_player = put_in(updated_player[:sword_rotation], new_rotation)
           players_excluding_player = List.delete(state.players, player_now)
-          Map.put(state, :players, [updated_player | players_excluding_player] )
+          Map.put(state, :players, [updated_player | players_excluding_player])
         end)
       end
     end
@@ -129,43 +142,38 @@ defmodule StabbyFlies.Game do
       down: correct_down
     }
 
-
     # Rotation (in radians) of the sword based off the keys pressed
-    ret_dir = case correct_direction do
-      %{left: false, right: false, up: false, down: false} -> player[:sword_rotation]
+    ret_dir =
+      case correct_direction do
+        %{left: false, right: false, up: false, down: false} -> player[:sword_rotation]
+        %{left: true, right: false, up: false, down: false} -> -:math.pi() / 2
+        %{left: true, right: false, up: true, down: false} -> -:math.pi() / 3
+        %{left: true, right: false, up: false, down: true} -> 3.92699
+        %{left: false, right: true, up: false, down: false} -> :math.pi() / 2
+        %{left: false, right: true, up: true, down: false} -> :math.pi() / 3
+        %{left: false, right: true, up: false, down: true} -> -3.92699
+        %{left: false, right: false, up: true, down: false} -> 0
+        %{left: false, right: false, up: false, down: true} -> :math.pi()
+      end
 
-      %{left: true, right: false, up: false, down: false} -> - :math.pi/2
-      %{left: true, right: false, up: true, down: false} -> - :math.pi/3
-      %{left: true, right: false, up: false, down: true} -> 3.92699
-
-
-      %{left: false, right: true, up: false, down: false} -> :math.pi/2
-      %{left: false, right: true, up: true, down: false} -> :math.pi/3
-      %{left: false, right: true, up: false, down: true} -> - 3.92699
-
-      %{left: false, right: false, up: true, down: false} -> 0
-      %{left: false, right: false, up: false, down: true} -> :math.pi
-    end
     ret_dir
   end
-  
 
   def do_damage_to_player(socket_id, damage) do
-    Agent.update(__MODULE__, fn(state) ->
+    Agent.update(__MODULE__, fn state ->
       player = get_player_by_socket_id(socket_id, state.players)
       new_hp = if player.hp - damage >= 0, do: player.hp - damage, else: 0
       updated_player = %{player | hp: new_hp}
       players_excluding_player = List.delete(state.players, player)
-      Map.put(state, :players, [updated_player | players_excluding_player] )
+      Map.put(state, :players, [updated_player | players_excluding_player])
     end)
-
   end
 
   def remove_player_by_socket_id(socket_id) do
-    Agent.update(__MODULE__, fn(state) ->
+    Agent.update(__MODULE__, fn state ->
       player = get_player_by_socket_id(socket_id, state.players)
       players_excluding_player = List.delete(state.players, player)
-      Map.put(state, :players, players_excluding_player )
+      Map.put(state, :players, players_excluding_player)
     end)
   end
 
@@ -182,13 +190,13 @@ defmodule StabbyFlies.Game do
       :ok
 
   """
-  def player_stabs(player) do 
+  def player_stabs(player) do
     damage = player.damage
     player_x = player.x + 20
     player_y = player.y
     player_width = 50
-    hitbox_x = player_x + :math.sin(player.sword_rotation)*50 - player_width + 10
-    hitbox_y = player_y - :math.cos(player.sword_rotation)*55 
+    hitbox_x = player_x + :math.sin(player.sword_rotation) * 50 - player_width + 10
+    hitbox_y = player_y - :math.cos(player.sword_rotation) * 55
 
     x = hitbox_x
     y = hitbox_y
@@ -197,9 +205,10 @@ defmodule StabbyFlies.Game do
 
     stab_data = %{x: x, y: y, width: width, height: height}
 
-    hit_players = get_players() 
-    |>  Enum.filter(fn x -> (x.socket_id != player.socket_id )end)
-    |>  Enum.filter(fn other_player -> 
+    hit_players =
+      get_players()
+      |> Enum.filter(fn x -> x.socket_id != player.socket_id end)
+      |> Enum.filter(fn other_player ->
         x = other_player.x
         y = other_player.y
 
@@ -209,36 +218,37 @@ defmodule StabbyFlies.Game do
         width = 80
         height = 60
 
-        is_hit = rectangles_overlap(stab_data, %{x: x, y: y, width: width, height: height})  
+        is_hit = rectangles_overlap(stab_data, %{x: x, y: y, width: width, height: height})
         if is_hit, do: do_damage_to_player(other_player.socket_id, damage), else: 0
-        is_hit 
+        is_hit
       end)
+
     update_last_stab_and_kill_count(player, hit_players, damage)
     hit_players
   end
 
   def update_last_stab_and_kill_count(player, hit_players, damage) do
-    killed_players = Enum.filter(hit_players, fn hit_player ->
-      hit_player.hp - damage <= 0
-    end)
+    killed_players =
+      Enum.filter(hit_players, fn hit_player ->
+        hit_player.hp - damage <= 0
+      end)
 
-    Agent.update(__MODULE__, fn(state) ->
+    Agent.update(__MODULE__, fn state ->
       player = get_player_by_socket_id(player.socket_id, state.players)
-      updated_player = %{player | last_stab: Time.utc_now}
-      updated_player = %{ updated_player | kill_count: player.kill_count + length(killed_players)}
+      updated_player = %{player | last_stab: Time.utc_now()}
+      updated_player = %{updated_player | kill_count: player.kill_count + length(killed_players)}
       players_excluding_player = List.delete(state.players, player)
-      Map.put(state, :players, [updated_player | players_excluding_player] )
+      Map.put(state, :players, [updated_player | players_excluding_player])
     end)
   end
-
 
   def player_can_stab(socket_id) do
     player = get_player_by_socket_id(socket_id)
 
     cooldown = 300
-    now = Time.utc_now
+    now = Time.utc_now()
 
-    can_stab = (Time.diff(now, player.last_stab, :milliseconds) >= cooldown)
+    can_stab = Time.diff(now, player.last_stab, :milliseconds) >= cooldown
     {player, can_stab}
   end
 
@@ -247,44 +257,45 @@ defmodule StabbyFlies.Game do
     x2 = rect2.x
 
     y1 = rect1.y
-    y2 = rect2.y 
+    y2 = rect2.y
 
     w1 = rect1.width
     w2 = rect2.width
 
     h1 = rect1.height
     h2 = rect2.height
-    !(x1+w1<x2 or x2+w2<x1 or y1+h1<y2 or y2+h2<y1)
+    !(x1 + w1 < x2 or x2 + w2 < x1 or y1 + h1 < y2 or y2 + h2 < y1)
   end
 
   defp update_x(x, speed) do
-    cond do 
-      (x + speed) < 0 -> 0
-      (x + speed) > 3000 -> 3000
-      (true) -> x + speed
+    cond do
+      x + speed < 0 -> 0
+      x + speed > 3000 -> 3000
+      true -> x + speed
     end
   end
 
   defp update_y(y, speed) do
-    cond do 
-      (y + speed) < -100 -> -100
-      (y + speed) > 270 -> 270
-      (true) -> y + speed
+    cond do
+      y + speed < -100 -> -100
+      y + speed > 270 -> 270
+      true -> y + speed
     end
   end
-  
+
   defp update_hp(hp, change, maxHp) do
-    cond do 
-      (hp + change) <= 0 -> 0
-      (hp + change) >= maxHp -> maxHp
-      (true) -> hp + change
+    cond do
+      hp + change <= 0 -> 0
+      hp + change >= maxHp -> maxHp
+      true -> hp + change
     end
   end
 
   defp start_y do
     Enum.random(-100..270)
   end
-  defp start_x do 
+
+  defp start_x do
     Enum.random(0..3000)
   end
 end

--- a/lib/stabby_flies/message.ex
+++ b/lib/stabby_flies/message.ex
@@ -2,7 +2,6 @@ defmodule StabbyFlies.Message do
   use Ecto.Schema
   import Ecto.Changeset
 
-
   schema "messages" do
     field :message, :string
     field :name, :string

--- a/lib/stabby_flies/message.ex
+++ b/lib/stabby_flies/message.ex
@@ -1,4 +1,7 @@
 defmodule StabbyFlies.Message do
+  @moduledoc """
+  Description about this module
+  """
   use Ecto.Schema
   import Ecto.Changeset
 

--- a/lib/stabby_flies/utils/socket_id_gen.ex
+++ b/lib/stabby_flies/utils/socket_id_gen.ex
@@ -3,20 +3,22 @@ defmodule StabbyFlies.SocketIdGen do
 
   def start_link do
     # Agent.stop(__MODULE__)
-    Agent.start_link(fn -> %{ "id": 0 } end, name: __MODULE__)
+    Agent.start_link(fn -> %{id: 0} end, name: __MODULE__)
   end
 
   def gen_id do
     x = Enum.random(0..200)
     id = get_id + 1
-    Agent.update(__MODULE__, fn(state) -> 
+
+    Agent.update(__MODULE__, fn state ->
       Map.put(state, :id, id)
     end)
+
     id
   end
 
   def get_id do
-    Agent.get(__MODULE__, fn(state) ->
+    Agent.get(__MODULE__, fn state ->
       state.id
     end)
   end

--- a/lib/stabby_flies/utils/socket_id_gen.ex
+++ b/lib/stabby_flies/utils/socket_id_gen.ex
@@ -1,4 +1,7 @@
 defmodule StabbyFlies.SocketIdGen do
+  @moduledoc """
+  Description about this module
+  """
   require Logger
 
   def start_link do

--- a/lib/stabby_flies_web/channels/room_channel.ex
+++ b/lib/stabby_flies_web/channels/room_channel.ex
@@ -1,4 +1,7 @@
 defmodule StabbyFliesWeb.RoomChannel do
+  @moduledoc """
+  Description about the use of this Module
+  """
   use StabbyFliesWeb, :channel
   require Logger
 
@@ -18,7 +21,7 @@ defmodule StabbyFliesWeb.RoomChannel do
 
   def handle_in("shout", payload, socket) do
     # Disabled until input is sanitized
-    # StabbyFlies.Message.changeset(%StabbyFlies.Message{}, payload) |> StabbyFlies.Repo.insert  
+    # StabbyFlies.Message.changeset(%StabbyFlies.Message{}, payload) |> StabbyFlies.Repo.insert
     # broadcast socket, "shout", payload
     {:noreply, socket}
   end

--- a/lib/stabby_flies_web/channels/room_channel.ex
+++ b/lib/stabby_flies_web/channels/room_channel.ex
@@ -5,12 +5,15 @@ defmodule StabbyFliesWeb.RoomChannel do
   alias StabbyFlies.Game
 
   def join("room:game", payload, socket) do
-    Logger.debug "Joined Lobby #{payload["nickname"]}"
-    socket = socket 
+    Logger.debug("Joined Lobby #{payload["nickname"]}")
+
+    socket =
+      socket
       |> assign(:albums, [])
       |> assign(:nickname, payload["nickname"])
-      send(self(), :after_join)
-      {:ok, socket}
+
+    send(self(), :after_join)
+    {:ok, socket}
   end
 
   def handle_in("shout", payload, socket) do
@@ -25,16 +28,17 @@ defmodule StabbyFliesWeb.RoomChannel do
 
     if can_stab do
       hit_players = Game.player_stabs(player)
-        
-      hit_players_data = hit_players
-      |> Enum.map(fn hit_player -> 
-        %{
-          socket_id: hit_player.socket_id,
-          damage: player.damage
-        }
-        end
-        )
-      broadcast socket, "stab", %{socket_id: socket.id, hit_players_data: hit_players_data}
+
+      hit_players_data =
+        hit_players
+        |> Enum.map(fn hit_player ->
+          %{
+            socket_id: hit_player.socket_id,
+            damage: player.damage
+          }
+        end)
+
+      broadcast(socket, "stab", %{socket_id: socket.id, hit_players_data: hit_players_data})
     end
 
     {:noreply, socket}
@@ -45,23 +49,24 @@ defmodule StabbyFliesWeb.RoomChannel do
   end
 
   def handle_in("move", payload, socket) do
-    player = Game.set_player_moving(socket.id, String.to_atom(payload["direction"]), payload["down"])
+    player =
+      Game.set_player_moving(socket.id, String.to_atom(payload["direction"]), payload["down"])
+
     {:noreply, socket}
   end
 
   def terminate(reason, socket) do
     Logger.debug("#{@name} > leave #{inspect(reason)}")
-    broadcast socket, "disconnect", %{id: socket.id}
+    broadcast(socket, "disconnect", %{id: socket.id})
     Game.remove_player_by_socket_id(socket.id)
   end
 
-
   def handle_info(:after_join, socket) do
-    IO.puts "After Join! Adding Player #{socket.id}"
-    IO.inspect socket
+    IO.puts("After Join! Adding Player #{socket.id}")
+    IO.inspect(socket)
     new_player = Game.add_player("#{socket.assigns.nickname}", socket.id)
 
-    broadcast socket, "connect", %{new_player: new_player, players: Game.get_players,}
+    broadcast(socket, "connect", %{new_player: new_player, players: Game.get_players()})
 
     # Disabled for now
     # StabbyFlies.Message.get_messages()
@@ -69,9 +74,9 @@ defmodule StabbyFliesWeb.RoomChannel do
     #     name: msg.name,
     #     message: msg.message,
     #   }) end)
-      push(socket, "initialize", %{
-        new_player: new_player
-      })
+    push(socket, "initialize", %{
+      new_player: new_player
+    })
 
     {:noreply, socket}
   end

--- a/lib/stabby_flies_web/channels/user_socket.ex
+++ b/lib/stabby_flies_web/channels/user_socket.ex
@@ -7,14 +7,13 @@ defmodule StabbyFliesWeb.UserSocket do
   channel "room:game", StabbyFliesWeb.RoomChannel
 
   def connect(_params, socket, _connect_info) do
-    id = StabbyFlies.SocketIdGen.gen_id
+    id = StabbyFlies.SocketIdGen.gen_id()
     {:ok, assign(socket, :user_id, id)}
   end
 
   def disconnect(params, socket) do
-    Logger.debug "DISCONENCT"
+    Logger.debug("DISCONENCT")
   end
 
   def id(socket), do: "#{socket.assigns.user_id}"
-
 end

--- a/mix.exs
+++ b/mix.exs
@@ -33,6 +33,7 @@ defmodule StabbyFlies.MixProject do
   # Type `mix help deps` for examples and options.
   defp deps do
     [
+      {:credo, "~> 1.0.0", only: [:dev, :test], runtime: false},
       {:phoenix, "~> 1.4.0"},
       {:phoenix_pubsub, "~> 1.1"},
       {:phoenix_ecto, "~> 4.0"},

--- a/mix.lock
+++ b/mix.lock
@@ -1,7 +1,9 @@
 %{
+  "bunt": {:hex, :bunt, "0.2.0", "951c6e801e8b1d2cbe58ebbd3e616a869061ddadcc4863d0a2182541acae9a38", [:mix], [], "hexpm"},
   "connection": {:hex, :connection, "1.0.4", "a1cae72211f0eef17705aaededacac3eb30e6625b04a6117c1b2db6ace7d5976", [:mix], [], "hexpm"},
   "cowboy": {:hex, :cowboy, "2.5.0", "4ef3ae066ee10fe01ea3272edc8f024347a0d3eb95f6fbb9aed556dacbfc1337", [:rebar3], [{:cowlib, "~> 2.6.0", [hex: :cowlib, repo: "hexpm", optional: false]}, {:ranch, "~> 1.6.2", [hex: :ranch, repo: "hexpm", optional: false]}], "hexpm"},
   "cowlib": {:hex, :cowlib, "2.6.0", "8aa629f81a0fc189f261dc98a42243fa842625feea3c7ec56c48f4ccdb55490f", [:rebar3], [], "hexpm"},
+  "credo": {:hex, :credo, "1.0.0", "aaa40fdd0543a0cf8080e8c5949d8c25f0a24e4fc8c1d83d06c388f5e5e0ea42", [:mix], [{:bunt, "~> 0.2.0", [hex: :bunt, repo: "hexpm", optional: false]}, {:jason, "~> 1.0", [hex: :jason, repo: "hexpm", optional: false]}], "hexpm"},
   "db_connection": {:hex, :db_connection, "2.0.2", "440c05518b0bdca0469dafaf45403597430448c1281def14ef9ccaa41833ea1e", [:mix], [{:connection, "~> 1.0.2", [hex: :connection, repo: "hexpm", optional: false]}], "hexpm"},
   "decimal": {:hex, :decimal, "1.5.0", "b0433a36d0e2430e3d50291b1c65f53c37d56f83665b43d79963684865beab68", [:mix], [], "hexpm"},
   "distillery": {:hex, :distillery, "1.5.5", "c6132d5c0152bdce6850fb6c942d58f1971b169b6965d908dc4e8767cfa51a95", [:mix], [], "hexpm"},

--- a/priv/repo/migrations/20181118041018_create_messages.exs
+++ b/priv/repo/migrations/20181118041018_create_messages.exs
@@ -8,6 +8,5 @@ defmodule StabbyFlies.Repo.Migrations.CreateMessages do
 
       timestamps()
     end
-
   end
 end

--- a/test/stabby_flies/game_test.exs
+++ b/test/stabby_flies/game_test.exs
@@ -1,42 +1,38 @@
 defmodule StabbyFlies.GameTest do
-    use ExUnit.Case, async: true
+  use ExUnit.Case, async: true
 
-    # setup do
-      # game = start_supervised!(StabbyFlies.Game)
-      # %{game: game}
-    # end
-  
-    # test "spawns buckets", %{game: game} do
-    #     # assert KV.Registry.lookup(game, "shopping") != :error
-    
-    #     # KV.Registry.create(game, "shopping")
-    #     assert {:ok, bucket} = StabbyFlies.Game.lookup(game, "shopping")
-    
-    #     KV.Bucket.put(bucket, "milk", 1)
-    #     assert KV.Bucket.get(bucket, "milk") == 1
-    #   end
+  # setup do
+  # game = start_supervised!(StabbyFlies.Game)
+  # %{game: game}
+  # end
 
-    test "adds p" do 
-        player_one = StabbyFlies.Game.add_player("player1", 1)
-        assert StabbyFlies.Game.get_players |> length == 1
-    end
+  # test "spawns buckets", %{game: game} do
+  #     # assert KV.Registry.lookup(game, "shopping") != :error
 
-    test "removes p" do 
-      players_length = StabbyFlies.Game.get_players |> length
-      StabbyFlies.Game.add_player("player2", 2)
-      StabbyFlies.Game.remove_player_by_socket_id(2)
+  #     # KV.Registry.create(game, "shopping")
+  #     assert {:ok, bucket} = StabbyFlies.Game.lookup(game, "shopping")
 
-      assert StabbyFlies.Game.get_players |> length == players_length
-    end
+  #     KV.Bucket.put(bucket, "milk", 1)
+  #     assert KV.Bucket.get(bucket, "milk") == 1
+  #   end
 
-
-    test "moves p" do 
-      player_three = StabbyFlies.Game.add_player("player3", 3)
-      old_x = player_three[:x]
-      StabbyFlies.Game.move_player_by_socket_id(3, "left")
-      assert StabbyFlies.Game.get_player_by_socket_id(3)[:x] != old_x
-    end
-
-
+  test "adds p" do
+    player_one = StabbyFlies.Game.add_player("player1", 1)
+    assert StabbyFlies.Game.get_players() |> length == 1
   end
-  
+
+  test "removes p" do
+    players_length = StabbyFlies.Game.get_players() |> length
+    StabbyFlies.Game.add_player("player2", 2)
+    StabbyFlies.Game.remove_player_by_socket_id(2)
+
+    assert StabbyFlies.Game.get_players() |> length == players_length
+  end
+
+  test "moves p" do
+    player_three = StabbyFlies.Game.add_player("player3", 3)
+    old_x = player_three[:x]
+    StabbyFlies.Game.move_player_by_socket_id(3, "left")
+    assert StabbyFlies.Game.get_player_by_socket_id(3)[:x] != old_x
+  end
+end


### PR DESCRIPTION
This PR adds code readability using the formatter and fixes some suggestions based on [credo](https://github.com/rrrene/credo) as a code analyzer for elixir.

For future PRs a good idea could be to set up a continuous integration system (Travis ci, Circle ci, semaphore or other), and require the code with a standard format and passing the code analysis to merge a PR.

For now, this are the commands that could be used:

```shell
mix format
```
```shell
mix credo --strict
```
Updating the basecode using the formatter, and the analyzer will help other to contribute to your project :)

### TODO
 - Fix suggestions based on `mix credo --strict`